### PR TITLE
feat: wire helius devnet endpoints

### DIFF
--- a/drift-bots/.env.example
+++ b/drift-bots/.env.example
@@ -1,0 +1,26 @@
+# Environment: testnet or mainnet
+DRIFT_ENV=testnet
+
+# RPC and wallet (testnet placeholders)
+RPC_URL=https://devnet.helius-rpc.com/?api-key=72f3b2b8-c204-48d5-9b4d-b612d10f04d4
+WS_URL=wss://devnet.helius-rpc.com/?api-key=72f3b2b8-c204-48d5-9b4d-b612d10f04d4
+WALLET_SECRET_KEY=replace_with_base58_or_path
+
+# Feature flags
+FEATURE_OBI_ENABLED=false
+FEATURE_TREND_ENABLED=true
+FEATURE_HEDGE_ENABLED=true
+
+# Orchestrator
+METRICS_PORT=9100
+LOG_LEVEL=INFO
+
+# Redis (feature flags live override)
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_DB=0
+REDIS_PASSWORD=
+
+# Grafana defaults (for docker-compose)
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin

--- a/drift-bots/Dockerfile
+++ b/drift-bots/Dockerfile
@@ -1,0 +1,10 @@
+# Simple Python runtime for bots
+FROM python:3.11-slim
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+RUN pip install --no-cache-dir poetry==1.8.3
+COPY pyproject.toml README.md ./
+RUN poetry config virtualenvs.create false && poetry install --no-root --no-interaction --no-ansi
+COPY . .
+CMD ["python", "-m", "orchestrator.main", "--env", "testnet"]

--- a/drift-bots/Makefile
+++ b/drift-bots/Makefile
@@ -1,0 +1,31 @@
+.PHONY: install run-jit run-hedge run-trend run-all fmt lint seed compose-up compose-down
+
+install:
+	poetry install --no-root
+
+seed:
+	poetry run python scripts/seed_flags.py
+
+run-jit:
+	poetry run python -m bots.jit.main --env $${DRIFT_ENV:-testnet} --metrics-port 9101
+
+run-hedge:
+	poetry run python -m bots.hedge.main --env $${DRIFT_ENV:-testnet} --metrics-port 9102
+
+run-trend:
+	poetry run python -m bots.trend.main --env $${DRIFT_ENV:-testnet} --metrics-port 9103
+
+run-all:
+	poetry run python -m orchestrator.main --env $${DRIFT_ENV:-testnet}
+
+fmt:
+	poetry run ruff check . --fix
+
+lint:
+	poetry run ruff check . && poetry run mypy .
+
+compose-up:
+	docker compose up -d
+
+compose-down:
+	docker compose down -v

--- a/drift-bots/README.md
+++ b/drift-bots/README.md
@@ -1,0 +1,36 @@
+# Drift Bots v0.2 (Testnet Alpha)
+
+Three‑bot system (JIT, Hedge stub, Trend v0.1), Prometheus metrics, basic kill‑switch, and secrets/config wiring.
+
+## Quick Start
+
+1. Copy this repo, then install:
+
+```bash
+poetry install --no-root
+cp .env.example .env
+```
+
+2. Seed feature flags:
+
+```bash
+poetry run python scripts/seed_flags.py
+```
+
+3. Run any bot (ports 9101–9103), or the orchestrator (port 9100):
+
+```bash
+make run-jit
+make run-hedge
+make run-trend
+make run-all
+```
+
+4. Scrape metrics at `http://localhost:<port>/metrics`.
+
+## Notes
+
+- Real Drift integration is stubbed: swap `MockDriftClient` → real client later using `driftpy` in `libs/drift/client.py`.
+- Kill‑switch thresholds come from `configs/risk/risk_modes.yaml`.
+- Bot params live under `configs/` per bot.
+- `.env.example` ships with default Helius devnet RPC and WebSocket endpoints.

--- a/drift-bots/bots/__init__.py
+++ b/drift-bots/bots/__init__.py
@@ -1,0 +1,1 @@
+# Bots package marker

--- a/drift-bots/bots/hedge/__init__.py
+++ b/drift-bots/bots/hedge/__init__.py
@@ -1,0 +1,1 @@
+# Hedge bot package marker

--- a/drift-bots/bots/hedge/main.py
+++ b/drift-bots/bots/hedge/main.py
@@ -1,0 +1,45 @@
+import argparse
+import asyncio
+import os
+import time
+import yaml
+from pathlib import Path
+from loguru import logger
+from libs.metrics import start_metrics, LOOP_LATENCY, ORDERS_PLACED
+from libs.drift.client import build_client_from_config
+
+HEDGE_CFG = Path("configs/hedge/routing.yaml")
+CORE_CFG = os.getenv("DRIFT_CFG", "configs/core/drift_client.yaml")
+
+async def run(env: str = "testnet", metrics_port: int | None = 9102, cfg_path: str = CORE_CFG):
+    if metrics_port:
+        start_metrics(metrics_port)
+    hed = yaml.safe_load(Path(HEDGE_CFG).read_text())["hedge"]
+    client = await build_client_from_config(cfg_path)
+    logger.info(f"Hedge bot (mode={hed['mode']}) starting – env={env}")
+
+    try:
+        while True:
+            t0 = time.perf_counter()
+            # In v0.2 we only log hedge intents (stub)
+            urgency = 0.5  # placeholder scoring
+            route = "ioc" if urgency >= hed["urgency_threshold"] else "passive"
+            logger.info(f"[HEDGE] intent: urgency={urgency:.2f} → route={route}")
+            ORDERS_PLACED.inc()
+            LOOP_LATENCY.observe(time.perf_counter() - t0)
+            await asyncio.sleep(2.0)
+    finally:
+        close = getattr(client, "close", None)
+        if asyncio.iscoroutinefunction(close):
+            await close()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", default=os.getenv("DRIFT_ENV", "testnet"))
+    parser.add_argument("--metrics-port", type=int, default=9102)
+    parser.add_argument("--cfg", default=CORE_CFG)
+    args = parser.parse_args()
+    try:
+        asyncio.run(run(env=args.env, metrics_port=args.metrics_port, cfg_path=args.cfg))
+    except KeyboardInterrupt:
+        logger.info("Hedge bot shutdown")

--- a/drift-bots/bots/jit/__init__.py
+++ b/drift-bots/bots/jit/__init__.py
@@ -1,0 +1,1 @@
+# JIT bot package marker

--- a/drift-bots/bots/jit/main.py
+++ b/drift-bots/bots/jit/main.py
@@ -1,0 +1,61 @@
+import argparse
+import asyncio
+import os
+import time
+from pathlib import Path
+import yaml
+from loguru import logger
+
+from libs.metrics import start_metrics, LOOP_LATENCY, ORDERS_PLACED, record_mid, INV_USD
+from libs.drift.client import build_client_from_config, Order
+
+JIT_CFG = Path("configs/jit/params.yaml")
+CORE_CFG = os.getenv("DRIFT_CFG", "configs/core/drift_client.yaml")
+
+async def run(env: str = "testnet", metrics_port: int | None = 9101, cfg_path: str = CORE_CFG):
+    if metrics_port:
+        start_metrics(metrics_port)
+    jit = yaml.safe_load(Path(JIT_CFG).read_text())["jit"]
+
+    client = await build_client_from_config(cfg_path)
+    logger.info(f"JIT Maker (wrapper) starting – env={env}, refresh={jit['refresh_ms']}ms")
+
+    try:
+        while True:
+            t0 = time.perf_counter()
+            # Use the wrapper's orderbook. Mock client synthesizes one.
+            ob = client.get_orderbook()
+            if not ob.bids or not ob.asks:
+                await asyncio.sleep(0.05)
+                continue
+            mid = (ob.bids[0][0] + ob.asks[0][0]) / 2.0
+            record_mid(mid)
+
+            spread = jit["spread_bps"] / 10000.0 * mid
+            bid = mid - spread / 2
+            ask = mid + spread / 2
+            size = float(jit["quote_size_usd"])  # USD notional (mock sizing)
+
+            _ = client.place_order(Order(side="buy", price=bid, size_usd=size))
+            _ = client.place_order(Order(side="sell", price=ask, size_usd=size))
+            ORDERS_PLACED.inc(2)
+
+            INV_USD.set(0.0)  # placeholder; wire real inventory later
+            LOOP_LATENCY.observe(time.perf_counter() - t0)
+            await asyncio.sleep(jit["refresh_ms"] / 1000.0)
+    finally:
+        close = getattr(client, "close", None)
+        if asyncio.iscoroutinefunction(close):
+            await close()  # type: ignore
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", default=os.getenv("DRIFT_ENV", "testnet"))
+    parser.add_argument("--metrics-port", type=int, default=9101)
+    parser.add_argument("--cfg", default=CORE_CFG)
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(run(env=args.env, metrics_port=args.metrics_port, cfg_path=args.cfg))
+    except KeyboardInterrupt:
+        logger.info("JIT Maker shutdown")

--- a/drift-bots/bots/trend/__init__.py
+++ b/drift-bots/bots/trend/__init__.py
@@ -1,0 +1,1 @@
+# Trend bot package marker

--- a/drift-bots/bots/trend/main.py
+++ b/drift-bots/bots/trend/main.py
@@ -1,0 +1,74 @@
+import argparse
+import asyncio
+import os
+import time
+import yaml
+from pathlib import Path
+from collections import deque
+from loguru import logger
+from libs.metrics import start_metrics, LOOP_LATENCY, ORDERS_PLACED
+from libs.drift.client import build_client_from_config
+
+TREND_CFG = Path("configs/trend/filters.yaml")
+CORE_CFG = os.getenv("DRIFT_CFG", "configs/core/drift_client.yaml")
+
+def macd(prices: list[float], fast: int, slow: int, signal: int) -> tuple[float, float]:
+    def ema(vals, n):
+        k = 2 / (n + 1)
+        e = vals[0]
+        out = []
+        for v in vals:
+            e = v * k + e * (1 - k)
+            out.append(e)
+        return out
+    if len(prices) < slow + signal:
+        return 0.0, 0.0
+    fast_ema = ema(prices, fast)
+    slow_ema = ema(prices, slow)
+    # Align to same length
+    length = min(len(fast_ema), len(slow_ema))
+    macd_line = [fast_ema[-length + i] - slow_ema[i] for i in range(length)]
+    sig_line = ema(macd_line, signal)
+    return macd_line[-1], sig_line[-1]
+
+async def run(env: str = "testnet", metrics_port: int | None = 9103, cfg_path: str = CORE_CFG):
+    if metrics_port:
+        start_metrics(metrics_port)
+    cfg = yaml.safe_load(Path(TREND_CFG).read_text())["trend"]
+    client = await build_client_from_config(cfg_path)
+    prices: deque[float] = deque(maxlen=500)
+    logger.info(f"Trend bot starting – env={env}")
+    try:
+        while True:
+            t0 = time.perf_counter()
+            ob = client.get_orderbook()
+            if ob.bids and ob.asks:
+                mid = (ob.bids[0][0] + ob.asks[0][0]) / 2.0
+                prices.append(mid)
+                trade_signal = None
+                if cfg.get("use_macd", True):
+                    m, s = macd(list(prices), cfg["macd"]["fast"], cfg["macd"]["slow"], cfg["macd"]["signal"])
+                    if m > s:
+                        trade_signal = "long"
+                    elif m < s:
+                        trade_signal = "short"
+                if trade_signal:
+                    logger.info(f"[TREND] signal={trade_signal} @ mid={mid:.2f}")
+                    ORDERS_PLACED.inc()
+            LOOP_LATENCY.observe(time.perf_counter() - t0)
+            await asyncio.sleep(1.0)
+    finally:
+        close = getattr(client, "close", None)
+        if asyncio.iscoroutinefunction(close):
+            await close()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", default=os.getenv("DRIFT_ENV", "testnet"))
+    parser.add_argument("--metrics-port", type=int, default=9103)
+    parser.add_argument("--cfg", default=CORE_CFG)
+    args = parser.parse_args()
+    try:
+        asyncio.run(run(env=args.env, metrics_port=args.metrics_port, cfg_path=args.cfg))
+    except KeyboardInterrupt:
+        logger.info("Trend bot shutdown")

--- a/drift-bots/configs/core/drift_client.yaml
+++ b/drift-bots/configs/core/drift_client.yaml
@@ -1,0 +1,7 @@
+env: testnet
+rpc_url: ${RPC_URL}
+ws_url: ${WS_URL}
+wallet_secret_key: ${WALLET_SECRET_KEY}
+market: SOL-PERP
+heartbeat_ms: 1000
+use_mock: true  # set to false when wiring real driftpy

--- a/drift-bots/configs/hedge/routing.yaml
+++ b/drift-bots/configs/hedge/routing.yaml
@@ -1,0 +1,7 @@
+hedge:
+  mode: stub   # stub | cex
+  urgency_threshold: 0.7
+  passive:
+    max_slippage_bps: 3
+  ioc:
+    max_slippage_bps: 8

--- a/drift-bots/configs/jit/params.yaml
+++ b/drift-bots/configs/jit/params.yaml
@@ -1,0 +1,7 @@
+jit:
+  spread_bps: 6.0        # total spread (e.g., 6 bps → ±3 bps around mid)
+  skew_bps: 0.0          # static skew for now
+  quote_size_usd: 200
+  refresh_ms: 500
+  inventory_target: 0.0  # balanced
+  max_inventory_usd: 1500

--- a/drift-bots/configs/prometheus/prometheus.yml
+++ b/drift-bots/configs/prometheus/prometheus.yml
@@ -1,0 +1,16 @@
+global:
+  scrape_interval: 2s
+
+scrape_configs:
+  - job_name: "orchestrator"
+    static_configs:
+      - targets: ["host.docker.internal:9100", "localhost:9100"]
+  - job_name: "jit"
+    static_configs:
+      - targets: ["host.docker.internal:9101", "localhost:9101"]
+  - job_name: "hedge"
+    static_configs:
+      - targets: ["host.docker.internal:9102", "localhost:9102"]
+  - job_name: "trend"
+    static_configs:
+      - targets: ["host.docker.internal:9103", "localhost:9103"]

--- a/drift-bots/configs/risk/risk_modes.yaml
+++ b/drift-bots/configs/risk/risk_modes.yaml
@@ -1,0 +1,9 @@
+risk:
+  drawdown_soft_pct: -7.5
+  drawdown_hard_pct: -12.5
+  position_notional_cap_usd: 25000
+  leverage_cap: 10
+feature_flags:
+  obi_enabled: false
+  trend_enabled: true
+  hedge_enabled: true

--- a/drift-bots/configs/trend/filters.yaml
+++ b/drift-bots/configs/trend/filters.yaml
@@ -1,0 +1,11 @@
+trend:
+  use_macd: true
+  macd:
+    fast: 12
+    slow: 26
+    signal: 9
+  momentum_window: 14
+  atr_adx_filters:
+    enabled: false
+    atr_mult: 1.5
+    adx_min: 20

--- a/drift-bots/docker-compose.yml
+++ b/drift-bots/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.9"
+services:
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    ports: ["6379:6379"]
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./configs/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports: ["9090:9090"]
+
+  grafana:
+    image: grafana/grafana-oss
+    ports: ["3000:3000"]
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+
+  # Optional: run bots in containers (or run locally with poetry)
+  # bots:
+  #   build: .
+  #   environment:
+  #     - DRIFT_ENV=testnet
+  #     - REDIS_HOST=redis
+  #   depends_on: [redis, prometheus, grafana]

--- a/drift-bots/libs/__init__.py
+++ b/drift-bots/libs/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for libs.

--- a/drift-bots/libs/drift/__init__.py
+++ b/drift-bots/libs/drift/__init__.py
@@ -1,0 +1,1 @@
+# Drift client package marker

--- a/drift-bots/libs/drift/client.py
+++ b/drift-bots/libs/drift/client.py
@@ -1,0 +1,125 @@
+from dataclasses import dataclass
+from typing import Protocol, List, Tuple
+from loguru import logger
+import os
+import random
+import yaml
+
+@dataclass
+class Order:
+    side: str  # "buy" | "sell"
+    price: float
+    size_usd: float
+
+@dataclass
+class Orderbook:
+    bids: List[Tuple[float, float]]  # (price, size)
+    asks: List[Tuple[float, float]]
+
+class DriftClient(Protocol):
+    def place_order(self, order: Order) -> str:
+        ...
+    def cancel_all(self) -> None:
+        ...
+    def get_orderbook(self) -> Orderbook:
+        ...
+    async def close(self) -> None:
+        ...
+
+class MockDriftClient:
+    """Mock client for v0.2. Synthesizes a plausible orderbook around a drifting mid."""
+    def __init__(self, market: str = "SOL-PERP", start: float = 150.0, spread_bps: float = 6.0):
+        self.market = market
+        self.mid = float(start)
+        self.spread = spread_bps / 1e4
+
+    def _step(self) -> None:
+        # random‑walk mid with mild volatility (~7 bps sigma)
+        sigma = 0.0007
+        shock = random.gauss(0, sigma) * self.mid
+        self.mid = max(0.01, self.mid + shock)
+
+    def get_orderbook(self) -> Orderbook:
+        self._step()
+        half = self.mid * self.spread / 2
+        top_bid = self.mid - half
+        top_ask = self.mid + half
+        levels = 5
+        tick = max(self.mid * 1e-5, 0.01)
+        bids = [(round(top_bid - i * tick, 4), 10.0 + i) for i in range(levels)]
+        asks = [(round(top_ask + i * tick, 4), 10.0 + i) for i in range(levels)]
+        return Orderbook(bids=bids, asks=asks)
+
+    def place_order(self, order: Order) -> str:
+        oid = f"mock-{order.side}-{order.price:.2f}-{order.size_usd:.0f}"
+        logger.info(f"[MOCK] place_order {self.market} → {order}")
+        return oid
+
+    def cancel_all(self) -> None:
+        logger.info(f"[MOCK] cancel_all {self.market}")
+
+    async def close(self) -> None:
+        return None
+
+# Optional real client (skeleton)
+try:
+    import driftpy  # type: ignore
+except Exception:
+    driftpy = None
+
+class DriftpyClient:
+    """Skeleton for real Drift integration. Fill RPC, wallet, market wiring in v0.3."""
+    def __init__(self, rpc_url: str, wallet_secret_key: str, market: str = "SOL-PERP", ws_url: str | None = None):
+        if driftpy is None:
+            raise RuntimeError("driftpy not installed. Add to pyproject and install.")
+        self.rpc_url = rpc_url
+        self.ws_url = ws_url
+        self.wallet_secret_key = wallet_secret_key
+        self.market = market
+        # TODO: initialize drift client, load market accounts, signer, etc.
+
+    def place_order(self, order: Order) -> str:
+        # TODO: translate USD size to contracts/quote size, build instruction, send TX
+        return "txsig_placeholder"
+
+    def cancel_all(self) -> None:
+        # TODO
+        return None
+
+    def get_orderbook(self) -> Orderbook:
+        # TODO: fetch from Drift markets/orderbook accounts
+        return Orderbook(bids=[], asks=[])
+
+    async def close(self) -> None:
+        # TODO: close websockets if any
+        return None
+
+async def build_client_from_config(cfg_path: str) -> DriftClient:
+    """Builder reads YAML with env‑var interpolation and returns a client."""
+    text = os.path.expandvars(open(cfg_path, "r").read())
+    cfg = yaml.safe_load(text)
+    env = cfg.get("env", "testnet")
+    market = cfg.get("market", "SOL-PERP")
+    use_mock = bool(cfg.get("use_mock", True))
+
+    if use_mock:
+        logger.info(f"Using MockDriftClient for {market} ({env})")
+        return MockDriftClient(market=market)
+
+    rpc = cfg.get("rpc_url") or os.getenv("DRIFT_RPC_URL")
+    ws = cfg.get("ws_url") or os.getenv("DRIFT_WS_URL")
+    secret = cfg.get("wallet_secret_key") or os.getenv("DRIFT_KEYPAIR_PATH")
+    if not rpc or not secret:
+        raise RuntimeError("rpc_url and wallet_secret_key/DRIFT_KEYPAIR_PATH are required for real client")
+    logger.info(f"Using DriftpyClient for {market} ({env}) via {rpc}")
+    return DriftpyClient(rpc_url=rpc, wallet_secret_key=secret, market=market, ws_url=ws)
+
+if __name__ == "__main__":
+    import asyncio
+    async def _smoke():
+        client = await build_client_from_config(os.getenv("DRIFT_CFG", "configs/core/drift_client.yaml"))
+        ob = client.get_orderbook()
+        if ob.bids and ob.asks:
+            mid = (ob.bids[0][0] + ob.asks[0][0]) / 2
+            logger.info(f"Top‑of‑book mid={mid:.4f} (b={ob.bids[0][0]:.4f} a={ob.asks[0][0]:.4f})")
+    asyncio.run(_smoke())

--- a/drift-bots/libs/flags.py
+++ b/drift-bots/libs/flags.py
@@ -1,0 +1,39 @@
+import os
+
+try:
+    import redis  # type: ignore
+except Exception:
+    redis = None
+
+REDIS_HOST = os.getenv("REDIS_HOST", "127.0.0.1")
+REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
+REDIS_DB = int(os.getenv("REDIS_DB", "0"))
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")
+
+_client = None
+
+def _get_client():
+    global _client
+    if _client is None and redis is not None:
+        _client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, password=REDIS_PASSWORD)
+    return _client
+
+FLAG_KEYS = {
+    "obi_enabled": "feature:obi:enabled",
+    "trend_enabled": "feature:trend:enabled",
+    "hedge_enabled": "feature:hedge:enabled",
+}
+
+def get_flag(name: str, fallback: bool) -> bool:
+    """Read feature flag from Redis; fallback to local default."""
+    key = FLAG_KEYS.get(name, name)
+    c = _get_client()
+    if c is None:
+        return fallback
+    try:
+        v = c.get(key)
+        if v is None:
+            return fallback
+        return v.decode().lower() in ("1", "true", "yes", "on")
+    except Exception:
+        return fallback

--- a/drift-bots/libs/market_data.py
+++ b/drift-bots/libs/market_data.py
@@ -1,0 +1,19 @@
+import random
+import time
+from dataclasses import dataclass
+
+@dataclass
+class Tick:
+    ts_ms: int
+    mid: float
+
+class SimMarketData:
+    """Simple random‑walk midprice simulator for testnet v0.2."""
+    def __init__(self, start: float = 150.0, vol_bps: float = 5.0):
+        self.mid = start
+        self.vol = vol_bps / 10000.0
+
+    def next(self) -> Tick:
+        shock = random.gauss(0, self.vol) * self.mid
+        self.mid = max(1e-6, self.mid + shock)
+        return Tick(int(time.time() * 1000), float(self.mid))

--- a/drift-bots/libs/metrics.py
+++ b/drift-bots/libs/metrics.py
@@ -1,0 +1,19 @@
+from prometheus_client import Counter, Gauge, Summary, start_http_server
+
+ORDERS_PLACED = Counter("orders_placed_total", "Total number of orders the bot attempted")
+FILLS = Counter("fills_total", "Total number of fills (mock in v0.2)")
+LOOP_LATENCY = Summary("loop_latency_seconds", "Per‑tick loop latency")
+MIDPRICE = Gauge("mid_price", "Current mid price (mock)")
+INV_USD = Gauge("inventory_usd", "Inventory notional in USD (mock)")
+PNL_USD = Gauge("pnl_usd", "PnL in USD (mock)")
+
+_started = False
+
+def start_metrics(port: int) -> None:
+    global _started
+    if not _started:
+        start_http_server(port)
+        _started = True
+
+def record_mid(mid: float) -> None:
+    MIDPRICE.set(mid)

--- a/drift-bots/libs/risk/__init__.py
+++ b/drift-bots/libs/risk/__init__.py
@@ -1,0 +1,1 @@
+# Risk package marker

--- a/drift-bots/libs/risk/kill_switch.py
+++ b/drift-bots/libs/risk/kill_switch.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class RiskConfig:
+    drawdown_soft_pct: float
+    drawdown_hard_pct: float
+    position_notional_cap_usd: float
+    leverage_cap: float
+
+class KillSwitch:
+    def __init__(self, cfg: RiskConfig):
+        self.cfg = cfg
+        self.enabled = False
+        self.equity_peak = None
+
+    def update_equity(self, equity_usd: float) -> Optional[str]:
+        if self.equity_peak is None:
+            self.equity_peak = equity_usd
+            return None
+        self.equity_peak = max(self.equity_peak, equity_usd)
+        dd_pct = 100.0 * (equity_usd - self.equity_peak) / self.equity_peak
+        if dd_pct <= self.cfg.drawdown_hard_pct:
+            self.enabled = True
+            return f"HARD kill: drawdown {dd_pct:.2f}% ≤ {self.cfg.drawdown_hard_pct}%"
+        if dd_pct <= self.cfg.drawdown_soft_pct:
+            return f"SOFT alert: drawdown {dd_pct:.2f}% ≤ {self.cfg.drawdown_soft_pct}%"
+        return None
+
+    def should_trade(self) -> bool:
+        return not self.enabled

--- a/drift-bots/orchestrator/__init__.py
+++ b/drift-bots/orchestrator/__init__.py
@@ -1,0 +1,1 @@
+# Orchestrator package marker

--- a/drift-bots/orchestrator/main.py
+++ b/drift-bots/orchestrator/main.py
@@ -1,0 +1,30 @@
+import argparse
+import asyncio
+import os
+from loguru import logger
+from libs.metrics import start_metrics
+from bots.jit.main import run as run_jit
+from bots.hedge.main import run as run_hedge
+from bots.trend.main import run as run_trend
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", default=os.getenv("DRIFT_ENV", "testnet"))
+    parser.add_argument("--metrics-port", type=int, default=int(os.getenv("METRICS_PORT", 9100)))
+    args = parser.parse_args()
+
+    start_metrics(args.metrics_port)
+    logger.info(f"Orchestrator starting on {args.env} – metrics @ {args.metrics_port}")
+
+    # Launch all three bots concurrently
+    await asyncio.gather(
+        run_jit(env=args.env, metrics_port=None),
+        run_hedge(env=args.env, metrics_port=None),
+        run_trend(env=args.env, metrics_port=None),
+    )
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Orchestrator shutdown")

--- a/drift-bots/pyproject.toml
+++ b/drift-bots/pyproject.toml
@@ -1,0 +1,36 @@
+[tool.poetry]
+name = "drift-bots"
+version = "0.2.0"
+description = "v0.2 testnet alpha: JIT + Hedge stub + Trend bot with Prometheus metrics"
+authors = ["AForged MM Team <mm@example.com>"]
+readme = "README.md"
+packages = [
+  { include = "bots" },
+  { include = "libs" },
+  { include = "orchestrator" }
+]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<3.13"
+PyYAML = "^6.0"
+numpy = "^1.26"
+pandas = "^2.2"
+prometheus-client = "^0.20.0"
+loguru = "^0.7.2"
+httpx = "^0.27.0"
+uvloop = {version = "^0.20.0", markers = "sys_platform == 'linux'"}
+
+[tool.poetry.group.dev.dependencies]
+ruff = "^0.5.0"
+mypy = "^1.10.0"
+
+[tool.ruff]
+line-length = 100
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/drift-bots/scripts/seed_flags.py
+++ b/drift-bots/scripts/seed_flags.py
@@ -1,0 +1,22 @@
+import yaml
+from pathlib import Path
+
+FLAGS = {
+    "feature_flags": {
+        "obi_enabled": False,
+        "trend_enabled": True,
+        "hedge_enabled": True,
+    }
+}
+
+OUT = Path("configs/risk/risk_modes.yaml")
+
+if __name__ == "__main__":
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    if OUT.exists():
+        data = yaml.safe_load(OUT.read_text()) or {}
+    else:
+        data = {}
+    data.update(FLAGS)
+    OUT.write_text(yaml.safe_dump(data, sort_keys=False))
+    print(f"Seeded flags → {OUT}")

--- a/drift-bots/tests/test_drift_client.py
+++ b/drift-bots/tests/test_drift_client.py
@@ -1,0 +1,11 @@
+import os
+import asyncio
+from libs.drift.client import build_client_from_config
+
+async def _build_and_fetch():
+    client = await build_client_from_config(os.getenv("DRIFT_CFG", "configs/core/drift_client.yaml"))
+    ob = client.get_orderbook()
+    assert hasattr(ob, "bids") and hasattr(ob, "asks")
+
+def test_build_and_orderbook():
+    asyncio.run(_build_and_fetch())

--- a/drift-bots/tests/test_hedge_main.py
+++ b/drift-bots/tests/test_hedge_main.py
@@ -1,0 +1,5 @@
+import inspect
+from bots.hedge.main import run
+
+def test_run_is_coroutine():
+    assert inspect.iscoroutinefunction(run)

--- a/drift-bots/tests/test_trend_main.py
+++ b/drift-bots/tests/test_trend_main.py
@@ -1,0 +1,5 @@
+import inspect
+from bots.trend.main import run
+
+def test_run_is_coroutine():
+    assert inspect.iscoroutinefunction(run)


### PR DESCRIPTION
## Summary
- add drift-bots project and default env file
- read optional WebSocket URL in drift client config
- document Helius devnet RPC/WebSocket usage

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac91a7e9188328b5e856f87ecdfa98